### PR TITLE
optimized

### DIFF
--- a/on-boarding/task-3/factorial.py
+++ b/on-boarding/task-3/factorial.py
@@ -1,17 +1,12 @@
 class FactorialCalculator:
     def __init__(self):
-        self.memo = {}
-
-    def factorial(self, n):
+        self.memo = {0: 1}
+    @staticmethod
+    def factorial(n):
         if n < 0:
             raise ValueError("Factorial is not defined for negative numbers.")
-        if n in self.memo:
-            return self.memo[n]
 
-        if n == 0:
-            result = 1
-        else:
-            result = n * self.factorial(n - 1)
+        if n not in FactorialCalculator.memo:
+            FactorialCalculator.memo[n] = n * FactorialCalculator.factorial(n - 1)
 
-        self.memo[n] = result
-        return result
+        return FactorialCalculator.memo[n]


### PR DESCRIPTION
Summary:
         1.Use a class method: Since the factorial method doesn't rely on any instance-specific variables, you can make it a class 
         method by adding the @staticmethod decorator. This avoids the need to instantiate the FactorialCalculator class before 
         calling the factorial method.
        2.Use a default value for the memo dictionary: Instead of initializing self.memo as an empty dictionary in the constructor, 
        you can use a default value of {0: 1}. This eliminates the need to check if n is in self.memo before performing the lookup.
        
        